### PR TITLE
binding.gyp: add -lmraa to ldflags

### DIFF
--- a/src/binding.gyp
+++ b/src/binding.gyp
@@ -2,7 +2,8 @@
 	"targets":[
 		{
 			"target_name": "hx711",
-			"sources": ["hx711.cc", "HX711.cpp"]
+			"sources": ["hx711.cc", "HX711.cpp"],
+			"ldflags": ["-lmraa"]
 		}
 	]
 }


### PR DESCRIPTION
This fixes your node module not linking to mraa
